### PR TITLE
Fix missing mime-subtype and update tests

### DIFF
--- a/AcceptHeader.php
+++ b/AcceptHeader.php
@@ -49,12 +49,18 @@ class AcceptHeader extends \ArrayObject {
         foreach ($items as $item) {
             $elems = explode(';', $item);
 
-            $acceptElement = array();
             $mime = current($elems);
-            list($type, $subtype) = explode('/', $mime);
-            $acceptElement['type'] = trim($type);
-            $acceptElement['subtype'] = trim($subtype);
-            $acceptElement['raw'] = $mime;
+            $types = explode('/', $mime);
+
+            if (!isset($types[1])) {
+                continue;
+            }
+
+            $acceptElement = array(
+                'raw'     => $mime,
+                'type'    => trim($types[0]),
+                'subtype' => trim($types[1])
+            );
 
             $acceptElement['params'] = array();
             while(next($elems)) {

--- a/tests/AcceptHeaderTest.php
+++ b/tests/AcceptHeaderTest.php
@@ -2,7 +2,9 @@
 
 require 'AcceptHeader.php';
 
-class ContainerTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ContainerTest extends TestCase
 {
 
     public function testHeader1() 
@@ -29,6 +31,12 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('text/html', $this->_getMedia($acceptHeader[1]));
         $this->assertEquals('text/*', $this->_getMedia($acceptHeader[2]));
         $this->assertEquals('*/*', $this->_getMedia($acceptHeader[3]));
+    }
+
+    public function testHeader4()
+    {
+        $acceptHeader = new AcceptHeader('text, text/html');
+        $this->assertEquals('text/html', $this->_getMedia($acceptHeader[0]));
     }
 
     private function _getMedia(array $mediaType) 


### PR DESCRIPTION
Hello.

Thanks for your work in this parser, we at [GNU social](https://notabug.org/diogo/gnu-social) have been happily using it for a while now. However, a recent [issue](https://notabug.org/diogo/gnu-social/issues/60) reported some errors with this code. For some strange request, the value in `$_SERVER['HTTP_ACCEPT']` contained invalid mime syntax (no subtype), causing undefined offset errors. I've pushed a small fix for this situation and also updated the tests.